### PR TITLE
Add `playerVars` prop for adding player parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ import YoutubePlayer from 'react-youtube-player';
  * @property {String|Number} width (default: '100%').
  * @property {String|Number} height (default: '100%').
  * @property {YoutubePlayer~playbackState} playbackState
+ * @property {object} playerVars Parameters to be passed to player (https://developers.google.com/youtube/iframe_api_reference)
  */
 <YoutubePlayer
     videoId=''
     playbackState='unstarted'
+    playerVars={{showinfo: 0, controls: 0}}
 />
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,15 +47,17 @@ class ReactYoutubePlayer extends React.Component {
         onPlay: React.PropTypes.func,
         onPause: React.PropTypes.func,
         onBuffer: React.PropTypes.func,
-
         // https://developers.google.com/youtube/iframe_api_reference#onError
-        onError: React.PropTypes.func
+        onError: React.PropTypes.func,
+
+        playerVars: React.PropTypes.object
     };
 
     static defaultProps = {
         width: '100%',
         height: '100%',
         playbackState: 'unstarted',
+        playerVars: {},
         onEnd: () => {},
         onPlay: () => {},
         onPause: () => {},
@@ -64,7 +66,11 @@ class ReactYoutubePlayer extends React.Component {
     };
 
     componentDidMount () {
-        this.player = YoutubePlayer(this.refs.player);
+        this.player = YoutubePlayer(this.refs.player, {
+            playerVars: {
+                ... this.props.playerVars
+            }
+        });
 
         this.bindEvent();
 

--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,7 @@ class ReactYoutubePlayer extends React.Component {
 
     componentDidMount () {
         this.player = YoutubePlayer(this.refs.player, {
-            playerVars: {
-                ... this.props.playerVars
-            }
+            playerVars: this.props.playerVars
         });
 
         this.bindEvent();


### PR DESCRIPTION
`playerVars` allow user to add player parameters for hiding youtube video description, controls etc. The name is chosen so because of [corresponding name in youtube-iframe-api](https://developers.google.com/youtube/iframe_api_reference).

`playerVars` is an object which can take same parameters as passed to `iframe` inserted manually. User of the component can hide the video description and controls with:

```js
<YoutubePlayer
    videoId='qfexgwzmU_U'
    playbackState={trailer.playbackState}
    playerVars={{showinfo: 0, controls: 0}}
/>
```