### PR TITLE
added cued and unstarted playbackState events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,9 @@ type PropsType = {|
   // https://developers.google.com/youtube/iframe_api_reference#onError
   onError: Function,
   onPause: Function,
-  onPlay: Function
+  onPlay: Function,
+  onCued: Function,
+  onUnstarted: Function
 |};
 
 class ReactYoutubePlayer extends PureComponent {
@@ -91,10 +93,12 @@ class ReactYoutubePlayer extends PureComponent {
   static defaultProps = {
     configuration: {},
     onBuffer: () => {},
+    onCued: () => {},
     onEnd: () => {},
     onError: () => {},
     onPause: () => {},
     onPlay: () => {},
+    onUnstarted: () => {},
     playbackState: 'unstarted'
   };
 
@@ -154,6 +158,10 @@ class ReactYoutubePlayer extends PureComponent {
         this.props.onPause(event);
       } else if (realPlaybackState === 'buffering') {
         this.props.onBuffer(event);
+      } else if (realPlaybackState === 'cued') {
+        this.props.onCued(event);
+      } else if (realPlaybackState === 'unstarted') {
+        this.props.onUnstarted(event);
       }
     });
 


### PR DESCRIPTION
I am using this player with a list a videos and a custom "poster" element laid over top of the player until it is played. I want the player to be able to pause and maintain its state but when a user clicks on a different video in my playlist I need to re-add my custom poster over the video player. Currently without "cued" available the last event I get is "paused". This leaves the "unstarted" player visible. Not sure if there is a reason for not including these play back states but I figured I'd go ahead and include "unstarted" as well. 